### PR TITLE
Update resampling to change spacing in affine

### DIFF
--- a/medviz/preprocess/resampling.py
+++ b/medviz/preprocess/resampling.py
@@ -50,11 +50,11 @@ def resample(input_path, output_path, new_voxel_size, method):
                     ):
                         resampled_data[i, j, k] = data[orig_i, orig_j, orig_k]
     
+    # Adjust affine to reflect changed voxel spacing
+    new_affine = nib.affines.rescale_affine(affine,resampled_data.shape,new_voxel_size)
+    
     # Create a new NIfTI image with resampled data and the same affine
-    resampled_img = nib.Nifti1Image(resampled_data, affine)
-
-    # Edit resampled NIfTI image affine to reflect new voxel spacing
-    resampled_img.header['pixdim'][1:4]=new_voxel_size
+    resampled_img = nib.Nifti1Image(resampled_data, new_affine)
 
     # Save the resampled image to the output path
     save_path = save_path_file(output_path, suffix=".nii")

--- a/medviz/preprocess/resampling.py
+++ b/medviz/preprocess/resampling.py
@@ -49,12 +49,12 @@ def resample(input_path, output_path, new_voxel_size, method):
                         and 0 <= orig_k < data.shape[2]
                     ):
                         resampled_data[i, j, k] = data[orig_i, orig_j, orig_k]
-
-    # Edit header to reflect new voxel spacing
-    header['pixdim'][1:4]  = new_voxel_size
     
     # Create a new NIfTI image with resampled data and the same affine
-    resampled_img = nib.Nifti1Image(resampled_data, affine, header)
+    resampled_img = nib.Nifti1Image(resampled_data, affine)
+
+    # Edit resampled NIfTI image affine to reflect new voxel spacing
+    resampled_img.header['pixdim'][1:4]=new_voxel_size
 
     # Save the resampled image to the output path
     save_path = save_path_file(output_path, suffix=".nii")

--- a/medviz/preprocess/resampling.py
+++ b/medviz/preprocess/resampling.py
@@ -50,8 +50,11 @@ def resample(input_path, output_path, new_voxel_size, method):
                     ):
                         resampled_data[i, j, k] = data[orig_i, orig_j, orig_k]
 
+    # Edit header to reflect new voxel spacing
+    header['pixdim'][1:4]  = new_voxel_size
+    
     # Create a new NIfTI image with resampled data and the same affine
-    resampled_img = nib.Nifti1Image(resampled_data, affine)
+    resampled_img = nib.Nifti1Image(resampled_data, affine, header)
 
     # Save the resampled image to the output path
     save_path = save_path_file(output_path, suffix=".nii")


### PR DESCRIPTION
See [issue 3](https://github.com/mohsenhariri/medviz/issues/3) for issue.

Changed the affine for the resampled image to reflect spacing changes from resampling. Uses NiBabel implementation for rescaling affines to adjust image scaling.